### PR TITLE
Add dark scrolly interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# dond
+# Deal or No Deal
+
+A simple web implementation of the Deal or No Deal game. The page can be
+served statically so you do not need Python or Flask to play.
+
+## Playing locally
+
+Simply open `index.html` in your web browser. The `static/` folder contains
+the JavaScript and CSS files used by the page. A theme toggle in the top
+right lets you switch between dark and light modes.
+
+## Hosting on GitHub Pages
+
+Commit this repository to GitHub and enable Pages from the repository
+settings. Because everything is static you only need the `index.html` file
+and the `static/` directory. Once enabled the game is playable at
+`https://<user>.github.io/<repo>/`.
+
+If you prefer to run a local server you can still use the small Flask app
+provided:
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,10 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deal or No Deal</title>
+    <link rel="stylesheet" href="static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
+</head>
+<body class="light">
+    <div class="theme-toggle"><i class="fas fa-moon"></i></div>
+    <section id="intro" class="section">
+        <h1>Deal or No Deal</h1>
+        <p>Scroll down to play the game!</p>
+        <div class="scroll-down"><i class="fas fa-angle-down"></i></div>
+    </section>
+    <section id="game" class="section">
+        <div id="bank-offer" class="hidden"></div>
+        <div id="cases" class="cases"></div>
+        <div id="remaining"></div>
+    </section>
+    <script src="static/script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,131 @@
+const PRIZES = [0.01,1,5,10,25,50,75,100,200,300,400,500,750,1000,5000,10000,25000,50000,75000,100000,200000,300000,400000,500000,750000,1000000];
+const PALETTE = ["#c7647e","#317452","#51784d","#8e9755","#4c96d7","#7b67c5","#398489","#538282","#969696","#343637"];
+let shuffledCases=[],playerCase=null,remainingCases=[],round=0,casesToOpen=[6,5,4,3,2],offers=[];
+
+function shuffleCases(){
+    shuffledCases = PRIZES.slice().sort(()=>Math.random()-0.5);
+}
+
+function renderCases(){
+    const container=document.getElementById('cases');
+    container.innerHTML='';
+    shuffledCases.forEach((_,i)=>{
+        const div=document.createElement('div');
+        div.className='case';
+        div.id='case-'+(i+1);
+        div.innerText=i+1;
+        div.style.backgroundColor=PALETTE[i%PALETTE.length];
+        div.onclick=()=>chooseCase(i);
+        container.appendChild(div);
+    });
+}
+
+function chooseCase(index){
+    if(playerCase===null){
+        playerCase=index;
+        document.getElementById('case-'+(index+1)).classList.add('selected');
+        remainingCases=shuffledCases.map((_,i)=>i).filter(i=>i!==index);
+        nextRound();
+    }else if(remainingCases.includes(index)){
+        openCase(index);
+    }
+}
+
+function openCase(index){
+    const value=shuffledCases[index];
+    const div=document.getElementById('case-'+(index+1));
+    div.innerText=value;
+    div.classList.remove('selected');
+    div.classList.add('opened','reveal');
+    div.onclick=null;
+    remainingCases=remainingCases.filter(i=>i!==index);
+    updateRemaining();
+    checkRoundCompletion();
+}
+
+function updateRemaining(){
+    const values=remainingCases.map(i=>shuffledCases[i]);
+    document.getElementById('remaining').innerText='Remaining amounts: '+values.join(', ');
+}
+
+function bankerOffer(){
+    const values=remainingCases.map(i=>shuffledCases[i]);
+    const mean=values.reduce((a,b)=>a+b,0)/values.length;
+    const offer=Math.round(mean*(0.5+round*0.05));
+    offers.push(offer);
+    const bankDiv=document.getElementById('bank-offer');
+    bankDiv.innerHTML=`Bank offers £${offer} <button onclick="deal()">Deal</button> <button onclick="noDeal()">No Deal</button>`;
+    bankDiv.classList.remove('hidden');
+}
+
+function deal(){
+    alert('You won £'+offers[offers.length-1]);
+    location.reload();
+}
+
+function noDeal(){
+    document.getElementById('bank-offer').classList.add('hidden');
+    nextRound();
+}
+
+function checkRoundCompletion(){
+    const opened=PRIZES.length-1-remainingCases.length;
+    if(opened>=casesToOpen[round]) bankerOffer();
+}
+
+function nextRound(){
+    if(round>=casesToOpen.length){
+        if(remainingCases.length<=1){
+            endGame();
+        }else{
+            casesToOpen.push(1);
+            round++;
+        }
+    }else{
+        round++;
+    }
+}
+
+function endGame(){
+    const otherIndex=remainingCases[0];
+    const playerAmount=shuffledCases[playerCase];
+    const otherAmount=shuffledCases[otherIndex];
+    const finalOffer=Math.round((playerAmount+otherAmount)/2);
+    const dealNow=confirm(`Final offer £${finalOffer}. Deal?`);
+    if(dealNow){
+        alert('You won £'+finalOffer);
+    }else{
+        const swap=confirm('Swap your case?');
+        const amount=swap?otherAmount:playerAmount;
+        alert('You won £'+amount);
+    }
+    location.reload();
+}
+
+function setupScroll(){
+    const arrow=document.querySelector('.scroll-down');
+    arrow.addEventListener('click',()=>{
+        document.getElementById('game').scrollIntoView({behavior:'smooth'});
+    });
+}
+
+function setupTheme(){
+    const toggle=document.querySelector('.theme-toggle');
+    toggle.addEventListener('click',()=>{
+        const body=document.body;
+        body.classList.toggle('dark');
+        body.classList.toggle('light');
+        const icon=toggle.querySelector('i');
+        icon.classList.toggle('fa-moon');
+        icon.classList.toggle('fa-sun');
+    });
+}
+
+window.onload=()=>{
+    shuffleCases();
+    renderCases();
+    updateRemaining();
+    setupScroll();
+    setupTheme();
+    document.getElementById('remaining').innerText='Pick your case.';
+};

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,128 @@
+:root {
+    --pink: #c7647e;
+    --green: #317452;
+    --yellow-green: #51784d;
+    --pale-yellow: #8e9755;
+    --blue: #4c96d7;
+    --purple: #7b67c5;
+    --teal: #398489;
+    --muted-cyan: #538282;
+    --light-grey: #969696;
+    --dark-grey: #343637;
+
+    --bg-light: #f4f4f4;
+    --bg-dark: #222;
+    --text-light: #eee;
+    --text-dark: #111;
+
+    /* highlight color for opening cases */
+    --highlight: #c7647e;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    transition: background-color 0.5s, color 0.5s;
+}
+
+body.light {
+    background-color: var(--bg-light);
+    color: var(--text-dark);
+}
+
+body.dark {
+    background-color: var(--dark-grey);
+    color: var(--text-light);
+}
+
+.section {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}
+
+#intro {
+    background: linear-gradient(135deg, var(--blue), var(--purple));
+    color: var(--text-light);
+    text-align: center;
+}
+
+.scroll-down {
+    margin-top: 20px;
+    font-size: 2rem;
+    cursor: pointer;
+    animation: bounce 2s infinite;
+}
+
+@keyframes bounce {
+    0%, 20%, 50%, 80%, 100% {transform: translateY(0);}
+    40% {transform: translateY(-10px);}
+    60% {transform: translateY(-5px);}
+}
+
+.theme-toggle {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    font-size: 1.5rem;
+    cursor: pointer;
+    z-index: 10;
+}
+
+.cases {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 10px;
+    max-width: 600px;
+    margin: 20px auto;
+}
+
+.case {
+    padding: 15px;
+    border-radius: 4px;
+    background-color: var(--teal);
+    border: 2px solid var(--light-grey);
+    cursor: pointer;
+    transition: transform 0.2s, background-color 0.3s, box-shadow 0.3s;
+    color: var(--text-light);
+}
+
+.case:hover {
+    transform: scale(1.05);
+    background-color: var(--purple);
+}
+
+.case.opened {
+    background-color: var(--light-grey);
+    color: var(--dark-grey);
+    cursor: default;
+}
+
+.case.selected {
+    box-shadow: 0 0 10px 2px var(--highlight);
+}
+
+.case.reveal {
+    animation: reveal 0.6s ease;
+}
+
+@keyframes reveal {
+    from { background-color: var(--highlight); }
+    to { background-color: var(--light-grey); }
+}
+
+#bank-offer {
+    font-size: 1.5em;
+    margin: 20px;
+}
+
+.hidden {
+    display: none;
+}
+
+#remaining {
+    margin: 20px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deal or No Deal</title>
+    <link rel="stylesheet" href="static/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
+</head>
+<body class="light">
+    <div class="theme-toggle"><i class="fas fa-moon"></i></div>
+    <section id="intro" class="section">
+        <h1>Deal or No Deal</h1>
+        <p>Scroll down to play the game!</p>
+        <div class="scroll-down"><i class="fas fa-angle-down"></i></div>
+    </section>
+    <section id="game" class="section">
+        <div id="bank-offer" class="hidden"></div>
+        <div id="cases" class="cases"></div>
+        <div id="remaining"></div>
+    </section>
+    <script src="static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign page with intro section and dark/light theme toggle
- add color palette variables and smoother styles
- implement scroll start arrow and theme button in JS
- document theme toggle in README
- add highlight animations and update GitHub Pages instructions

## Testing
- `python -m py_compile app.py`
- `python -m http.server 8000` *(verified index served)*

------
https://chatgpt.com/codex/tasks/task_e_6870a6ba02308321a160f54026278338